### PR TITLE
Prevent log surging

### DIFF
--- a/otel-api-common/library/OTel/API/Common.hs
+++ b/otel-api-common/library/OTel/API/Common.hs
@@ -3,6 +3,7 @@ module OTel.API.Common
     -- $synopsis
     module OTel.API.Common.Attributes
   , module OTel.API.Common.CPS
+  , module OTel.API.Common.Handlers
   , module OTel.API.Common.InstrumentationScope
   , module OTel.API.Common.KV
   , module OTel.API.Common.Timestamp
@@ -10,6 +11,7 @@ module OTel.API.Common
 
 import OTel.API.Common.Attributes
 import OTel.API.Common.CPS
+import OTel.API.Common.Handlers
 import OTel.API.Common.InstrumentationScope
 import OTel.API.Common.KV
 import OTel.API.Common.Timestamp

--- a/otel-api-common/library/OTel/API/Common/Handlers.hs
+++ b/otel-api-common/library/OTel/API/Common/Handlers.hs
@@ -1,0 +1,7 @@
+module OTel.API.Common.Handlers
+  ( module OTel.API.Common.Handlers.OnException
+  , module OTel.API.Common.Handlers.OnTimeout
+  ) where
+
+import OTel.API.Common.Handlers.OnException
+import OTel.API.Common.Handlers.OnTimeout

--- a/otel-api-common/library/OTel/API/Common/Handlers/OnException.hs
+++ b/otel-api-common/library/OTel/API/Common/Handlers/OnException.hs
@@ -1,0 +1,7 @@
+module OTel.API.Common.Handlers.OnException
+  ( Internal.OnException
+  , Internal.askException
+  , Internal.askExceptionMetadata
+  ) where
+
+import qualified OTel.API.Common.Internal as Internal

--- a/otel-api-common/library/OTel/API/Common/Handlers/OnTimeout.hs
+++ b/otel-api-common/library/OTel/API/Common/Handlers/OnTimeout.hs
@@ -1,7 +1,7 @@
-module OTel.SDK.Trace.Handlers.OnTimeout
+module OTel.API.Common.Handlers.OnTimeout
   ( Internal.OnTimeout
   , Internal.askTimeoutMicros
   , Internal.askTimeoutMetadata
   ) where
 
-import qualified OTel.SDK.Trace.Internal as Internal
+import qualified OTel.API.Common.Internal as Internal

--- a/otel-api-common/library/OTel/API/Common/Internal.hs
+++ b/otel-api-common/library/OTel/API/Common/Internal.hs
@@ -6,12 +6,14 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -75,15 +77,42 @@ module OTel.API.Common.Internal
   , OnTimeout(..)
   , askTimeoutMicros
   , askTimeoutMetadata
+
+  , BufferedLoggerSpec(..)
+  , defaultBufferedLoggerSpec
+  , includeLogAggregateViaAeson
+  , withBufferedLogger
+  , withBufferedLoggerIO
+  , BufferedLogs
+  , insertBufferedLog
+  , insertBufferedLogWithAgg
+  , BufferedLog(..)
+  , toBufferedLog
+  , BufferedLogAgg(..)
   ) where
 
-import Data.Aeson (KeyValue((.=)), ToJSON(..), Value(..), object)
+import Control.Exception.Safe
+  ( SomeException(..), MonadCatch, MonadMask, MonadThrow, catchAny, displayException, finally
+  )
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.IO.Unlift (MonadUnliftIO(..))
+import Control.Monad.Logger.Aeson
+  ( Loc(..), LogLevel(..), LoggingT(..), Message(..), ToLogStr(..), LogSource, LogStr, MonadLogger
+  , MonadLoggerIO, SeriesElem, fromLogStr, logError
+  )
+import Control.Monad.Trans.Reader (ReaderT(..))
+import Data.Aeson (KeyValue((.=)), ToJSON(..), Value(..), (.:), (.:?), object)
+import Data.Aeson.KeyMap (KeyMap)
+import Data.Aeson.Types (Parser)
+import Data.ByteString (ByteString)
 import Data.DList (DList)
 import Data.Function ((&))
 import Data.HashMap.Strict (HashMap)
-import Data.Hashable (Hashable)
+import Data.Hashable (Hashable(..))
+import Data.IORef (IORef)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint, Type)
+import Data.Monoid (Ap(..))
 import Data.Proxy (Proxy(..))
 import Data.Sequence (Seq)
 import Data.String (IsString(fromString))
@@ -92,22 +121,25 @@ import Data.Vector (Vector)
 import Data.Word (Word16, Word32, Word8)
 import GHC.Float (float2Double)
 import Prelude hiding (span)
+import qualified Control.Concurrent as Concurrent
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson.Key
 import qualified Data.Aeson.KeyMap as Aeson.KeyMap
+import qualified Data.Aeson.Parser as Aeson.Parser
+import qualified Data.Aeson.Types as Aeson.Types
+import qualified Data.DList as DList
 import qualified Data.Foldable as Foldable
 import qualified Data.HashMap.Strict as HashMap
+import qualified Data.IORef as IORef
 import qualified Data.Maybe as Maybe
 import qualified Data.Scientific as Scientific
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Vector as Vector
-import Control.Exception.Safe (SomeException, MonadCatch, MonadMask, MonadThrow)
-import Control.Monad.Logger.Aeson (SeriesElem, LoggingT, MonadLogger, MonadLoggerIO)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Reader (ReaderT(..))
-import Data.Monoid (Ap(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO)
+import qualified System.Timeout as Timeout
+import qualified Data.Text.Encoding as Text.Encoding
 
 class KV (kv :: Type) where
   type KVConstraints kv :: Type -> Type -> Constraint
@@ -871,6 +903,7 @@ askException = OnException \someEx _pairs -> pure someEx
 askExceptionMetadata :: OnException [SeriesElem]
 askExceptionMetadata = OnException \_someEx pairs -> pure pairs
 
+type OnTimeout :: Type -> Type
 newtype OnTimeout a = OnTimeout
   { runOnTimeout :: Int -> [SeriesElem] -> LoggingT IO a
   } deriving
@@ -888,6 +921,377 @@ askTimeoutMicros = OnTimeout \timeoutMicros _pairs -> pure timeoutMicros
 
 askTimeoutMetadata :: OnTimeout [SeriesElem]
 askTimeoutMetadata = OnTimeout \_timeoutMicros pairs -> pure pairs
+
+data BufferedLoggerSpec = BufferedLoggerSpec
+  { -- | Predicate that determines if a log message should be buffered. The
+    -- default is no buffering, so all log messages are logged immediately.
+    bufferedLoggerSpecShouldBuffer
+      :: Loc -> LogSource -> LogLevel -> LogStr -> Bool
+    -- | The logger to wrap. For all unbuffered log messages, these
+    -- are passed to 'bufferedLoggerSpecLogger' immediately. For
+    -- buffered log messages, aggregates will eventually be passed
+    -- to 'bufferedLoggerSpecLogger' on the configured period (see
+    -- 'bufferedLoggerSpecFlushPeriod').
+  , bufferedLoggerSpecLogger
+      :: Loc -> LogSource -> LogLevel -> LogStr -> IO ()
+    -- | Buffered logs are regularly flushed from internal storage on this
+    -- period (in microseconds). The default is 5 minutes.
+  , bufferedLoggerSpecFlushPeriod :: Int
+    -- | Max amount of time allowed for flushing buffered logs (in
+    -- microseconds). The default is 10 seconds.
+  , bufferedLoggerSpecFlushTimeout :: Int
+    -- | Handler that is run if flushing buffered logs takes longer than
+    -- 'bufferedLoggerSpecFlushTimeout'. The default is to log the timeout using
+    -- 'bufferedLoggerSpecOnFlushExceptionLogger'. This may be overridden if the
+    -- timeout needs to be reported or dealt with via some means other than
+    -- logging. Note that if the handler throws a synchronous exception, that
+    -- exception will be caught and ignored.
+    --
+    -- The input argument is all remaining buffered logs that were unable to
+    -- be flushed within the timeout.
+  , bufferedLoggerSpecOnFlushTimeout
+      :: BufferedLogs -> OnTimeout ()
+    -- | Handler that is run if a synchronous exception is encountered during
+    -- log flushing. The default is to log the exception using
+    -- 'bufferedLoggerSpecOnFlushExceptionLogger'. This may be overridden if the
+    -- exception needs to be reported or dealt with via some means other than
+    -- logging. Note that if the handler rethrows the exception, the exception
+    -- will be caught and ignored.
+    --
+    -- The input arguments are the specific buffered log and aggregate
+    -- that encountered an exception during flushing.
+  , bufferedLoggerSpecOnFlushException
+      :: BufferedLog -> BufferedLogAgg -> OnException ()
+    -- | The 'bufferedLoggerSpecOnFlushTimeout' and
+    -- 'bufferedLoggerSpecOnFlushException' handlers are run using this logger.
+    -- This logger is intentionally different from 'bufferedLoggerSpecLogger',
+    -- as 'bufferedLoggerSpecLogger' may have ultimately been what triggered
+    -- running either handler in the first place.
+  , bufferedLoggerSpecOnFlushExceptionLogger
+      :: Loc -> LogSource -> LogLevel -> LogStr -> IO ()
+    -- | The internal storage tracks a count of each buffered log message's
+    -- occurrences (rather than tracking each occurrence) and each occurrence's
+    -- metadata (convenience for @monad-logger-aeson@ users). This function
+    -- enables including this aggregate info in the log message when it is
+    -- eventually logged. The default is to not include the aggregate info.
+    --
+    -- @monad-logger-aeson@ users may find it convenient to set this function
+    -- to @includeLogAggregateViaAeson Just@. This will include the aggregate in
+    -- full. If there is a risk that a buffered log's aggregated metadata may
+    -- exceed a logging system's max payload per message, 'Just' can be replaced
+    -- with a function that more carefully summarizes the metadata. For example,
+    -- to ignore the metadata altogether and instead only log the count of
+    -- aggregated messages, the following could be used:
+    --
+    -- @
+    -- 'includeLogAggregateViaAeson' \\bufferedLogAgg ->
+    --   'Just' $ 'object' ["count" '.=' 'bufferedLogAggCount' bufferedLogAgg]
+    -- @
+  , bufferedLoggerSpecIncludeLogAggregate
+      :: BufferedLog -> BufferedLogAgg -> [SeriesElem] -> LogStr
+  }
+
+defaultBufferedLoggerSpec :: BufferedLoggerSpec
+defaultBufferedLoggerSpec =
+  BufferedLoggerSpec
+    { bufferedLoggerSpecShouldBuffer = \_loc _logSource _logLevel _logStr ->
+        False
+    , bufferedLoggerSpecLogger = mempty
+    , bufferedLoggerSpecFlushPeriod = 300_000_000 -- 5 minutes
+    , bufferedLoggerSpecFlushTimeout = 10_000_000 -- 10 seconds
+    , bufferedLoggerSpecOnFlushTimeout = \unflushedLogs -> do
+        timeoutMicros <- askTimeoutMicros
+        pairs <- askTimeoutMetadata
+        logError $ "Flushing buffered logs took too long" :#
+          "timeoutMicros" .= timeoutMicros
+            : "unflushedLogs" .=
+                fmap
+                  ( \(bufferedLog, bufferedLogAgg) ->
+                      object
+                        [ "bufferedLog" .= bufferedLog
+                        , "bufferedLogAgg" .= bufferedLogAgg
+                        ]
+                  )
+                  (HashMap.toList unflushedLogs)
+            : pairs
+    , bufferedLoggerSpecOnFlushException = \bufferedLog bufferedLogAgg -> do
+        SomeException ex <- askException
+        pairs <- askExceptionMetadata
+        logError $ "Ignoring exception from flushing buffered log" :#
+          "exception" .= displayException ex
+            : "bufferedLog" .= bufferedLog
+            : "bufferedLogAgg" .= bufferedLogAgg
+            : pairs
+    , bufferedLoggerSpecOnFlushExceptionLogger = mempty
+    , bufferedLoggerSpecIncludeLogAggregate =
+        includeLogAggregateViaAeson $ const $ Nothing @BufferedLogAgg
+    }
+
+includeLogAggregateViaAeson
+  :: forall a
+   . (ToJSON a)
+  => (BufferedLogAgg -> Maybe a) -- ^ Summarizes the aggregated info
+  -> BufferedLog
+  -> BufferedLogAgg
+  -> [SeriesElem]
+  -> LogStr
+includeLogAggregateViaAeson summarizeAgg bufferedLog bufferedLogAgg pairs =
+  case logStrBytesOrMsgText of
+    Left logStrBytes -> toLogStr logStrBytes
+    Right msgText ->
+      toLogStr $ msgText :#
+        "bufferedLogAgg" .= summarizeAgg bufferedLogAgg : pairs
+  where
+  BufferedLog
+    { bufferedLogLogStr = logStrBytesOrMsgText
+    } = bufferedLog
+
+withBufferedLogger
+  :: forall m a
+   . (MonadUnliftIO m)
+  => BufferedLoggerSpec
+  -> ((Loc -> LogSource -> LogLevel -> LogStr -> IO ()) -> m a)
+  -> m a
+withBufferedLogger bufferedLoggerSpec action =
+  withRunInIO \runInIO ->
+    withBufferedLoggerIO bufferedLoggerSpec (runInIO . action)
+
+withBufferedLoggerIO
+  :: forall a
+   . BufferedLoggerSpec
+  -> ((Loc -> LogSource -> LogLevel -> LogStr -> IO ()) -> IO a)
+  -> IO a
+withBufferedLoggerIO bufferedLoggerSpec action = do
+  bufferedLogsRef <- IORef.newIORef mempty
+  Async.withAsync (mkWorker bufferedLogsRef) $ const do
+    action (logger' bufferedLogsRef) `finally` flush bufferedLogsRef
+  where
+  logger'
+    :: IORef BufferedLogs
+    -> Loc
+    -> LogSource
+    -> LogLevel
+    -> LogStr
+    -> IO ()
+  logger' bufferedLogsRef loc logSource logLevel logStr = do
+    if shouldBuffer loc logSource logLevel logStr then do
+      uncurry (buffer bufferedLogsRef) $ toBufferedLog loc logSource logLevel logStr
+    else do
+      logger loc logSource logLevel logStr
+
+  mkWorker :: IORef BufferedLogs -> IO ()
+  mkWorker bufferedLogsRef = do
+    Monad.forever do
+      Concurrent.threadDelay period
+      flush bufferedLogsRef
+
+  buffer :: IORef BufferedLogs -> BufferedLog -> KeyMap Value -> IO ()
+  buffer bufferedLogsRef bufferedLog meta = do
+    IORef.atomicModifyIORef' bufferedLogsRef \bufferedLogs ->
+      (insertBufferedLog bufferedLog meta bufferedLogs, ())
+
+  flush :: IORef BufferedLogs -> IO ()
+  flush bufferedLogsRef = do
+    flushedLogsRef <- IORef.newIORef mempty
+    bufferedLogs <- IORef.atomicModifyIORef' bufferedLogsRef (mempty,)
+    flip runLoggingT onFlushExLogger do
+      mResult <- withRunInIO \runInIO -> do
+        Timeout.timeout timeoutMicros $ runInIO do
+          Foldable.for_ (HashMap.toList bufferedLogs) \(bufferedLog, bufferedLogAgg) -> do
+            liftIO (flushElem flushedLogsRef bufferedLog bufferedLogAgg) `catchAny` \someEx -> do
+              runOnException (onFlushEx bufferedLog bufferedLogAgg) someEx loggingMeta `catchAny` \_ ->
+                -- If the custom handler throws a synchronous exception, we
+                -- ignore it, as we don't want to kill the async worker.
+                pure ()
+      flushedLogElems <- liftIO $ IORef.readIORef flushedLogsRef
+      let unflushedLogs = bufferedLogs `HashMap.difference` flushedLogElems
+      case mResult of
+        Just () -> pure ()
+        Nothing ->
+          runOnTimeout (onFlushTimeout unflushedLogs) timeoutMicros loggingMeta `catchAny` \_ ->
+            -- If the custom handler throws a synchronous exception, we ignore
+            -- it, as we don't want to kill the async worker.
+            pure ()
+
+  flushElem :: IORef BufferedLogs -> BufferedLog -> BufferedLogAgg -> IO ()
+  flushElem flushedLogsRef bufferedLog bufferedLogAgg = do
+    logger loc logSource logLevel $ includeLogAgg bufferedLog bufferedLogAgg loggingMeta
+    IORef.atomicModifyIORef' flushedLogsRef \flushedLogs ->
+      (insertBufferedLogWithAgg bufferedLog bufferedLogAgg flushedLogs, ())
+    where
+    BufferedLog
+      { bufferedLogLoc = loc
+      , bufferedLogLogSource = logSource
+      , bufferedLogLogLevel = logLevel
+      } = bufferedLog
+
+  loggingMeta :: [SeriesElem]
+  loggingMeta =
+    [ "bufferedLogger" .= object
+        [ "flushPeriod" .= period
+        , "flushTimeout" .= timeoutMicros
+        ]
+    ]
+
+  BufferedLoggerSpec
+    { bufferedLoggerSpecShouldBuffer = shouldBuffer
+    , bufferedLoggerSpecLogger = logger
+    , bufferedLoggerSpecFlushPeriod = period
+    , bufferedLoggerSpecFlushTimeout = timeoutMicros
+    , bufferedLoggerSpecOnFlushTimeout = onFlushTimeout
+    , bufferedLoggerSpecOnFlushException = onFlushEx
+    , bufferedLoggerSpecOnFlushExceptionLogger = onFlushExLogger
+    , bufferedLoggerSpecIncludeLogAggregate = includeLogAgg
+    } = bufferedLoggerSpec
+
+type BufferedLogs = HashMap BufferedLog BufferedLogAgg
+
+insertBufferedLog
+  :: BufferedLog
+  -> KeyMap Value
+  -> BufferedLogs
+  -> BufferedLogs
+insertBufferedLog bufferedLog meta =
+  insertBufferedLogWithAgg bufferedLog
+    BufferedLogAgg
+      { bufferedLogAggCount = 1
+      , bufferedLogAggMetas =
+          if Aeson.KeyMap.null meta then
+            mempty
+          else
+            DList.singleton meta
+      }
+
+insertBufferedLogWithAgg
+  :: BufferedLog
+  -> BufferedLogAgg
+  -> BufferedLogs
+  -> BufferedLogs
+insertBufferedLogWithAgg = HashMap.insertWith (<>)
+
+data BufferedLog = BufferedLog
+  { bufferedLogLoc :: Loc
+  , bufferedLogLogSource :: LogSource
+  , bufferedLogLogLevel :: LogLevel
+    -- | 'Right' when the log message was parsed as a 'Message', 'Left'
+    -- otherwise.
+  , bufferedLogLogStr :: Either ByteString Text
+  } deriving stock (Eq)
+
+instance Hashable BufferedLog where
+  hashWithSalt salt bufferedLog =
+    salt
+      `hashWithSalt` loc_filename
+      `hashWithSalt` loc_package
+      `hashWithSalt` loc_module
+      `hashWithSalt` loc_start
+      `hashWithSalt` logSource
+      `hashWithSalt` show logLevel
+      `hashWithSalt` logStrBytesOrMsgText
+    where
+    BufferedLog
+      { bufferedLogLoc =
+          Loc { loc_filename, loc_package, loc_module, loc_start }
+      , bufferedLogLogSource = logSource
+      , bufferedLogLogLevel = logLevel
+      , bufferedLogLogStr = logStrBytesOrMsgText
+      } = bufferedLog
+
+instance ToJSON BufferedLog where
+  toJSON bufferedLog =
+    object
+      [ "loc" .=
+          object
+            [ "package" .= loc_package
+            , "module" .= loc_module
+            , "file" .= loc_filename
+            , "line" .= fst loc_start
+            , "char" .= snd loc_start
+            ]
+      , "source" .= logSource
+      , "level" .=
+          case logLevel of
+            LevelDebug -> "debug"
+            LevelInfo -> "info"
+            LevelWarn -> "warn"
+            LevelError -> "error"
+            LevelOther otherLevel -> otherLevel
+      , "text" .=
+          case logStrBytesOrMsgText of
+            Left logStrBytes ->
+              case Text.Encoding.decodeUtf8' logStrBytes of
+                Left _unicodeEx -> "Log message could not be decoded via UTF-8"
+                Right text -> text
+            Right msgText -> msgText
+      ]
+    where
+    BufferedLog
+      { bufferedLogLoc =
+          Loc { loc_filename, loc_package, loc_module, loc_start }
+      , bufferedLogLogSource = logSource
+      , bufferedLogLogLevel = logLevel
+      , bufferedLogLogStr = logStrBytesOrMsgText
+      } = bufferedLog
+
+toBufferedLog
+  :: Loc
+  -> LogSource
+  -> LogLevel
+  -> LogStr
+  -> (BufferedLog, KeyMap Value)
+toBufferedLog loc logSource logLevel logStr =
+  ( BufferedLog
+      { bufferedLogLoc = loc
+      , bufferedLogLogSource = logSource
+      , bufferedLogLogLevel = logLevel
+      , bufferedLogLogStr
+      }
+  , meta
+  )
+  where
+  (bufferedLogLogStr, meta) =
+    case runAesonParser parseMessage logStrBytes of
+      Nothing -> (Left logStrBytes, mempty)
+      Just (text, keyMap) -> (Right text, keyMap)
+
+  logStrBytes = fromLogStr logStr
+
+  parseMessage :: Value -> Parser (Text, KeyMap Value)
+  parseMessage = Aeson.withObject "Message" \obj ->
+    (,) <$> obj .: "text" <*> (parsePairs =<< obj .:? "meta")
+
+  parsePairs :: Maybe Value -> Parser (KeyMap Value)
+  parsePairs = \case
+    Nothing -> pure mempty
+    Just value -> flip (Aeson.withObject "[Pair]") value \obj -> do
+      pure obj
+
+  runAesonParser :: (Value -> Parser a) -> ByteString -> Maybe a
+  runAesonParser parser =
+    Aeson.Parser.decodeStrictWith Aeson.json' (Aeson.Types.parse parser)
+
+data BufferedLogAgg = BufferedLogAgg
+  { bufferedLogAggCount :: Int
+  , bufferedLogAggMetas :: DList (KeyMap Value)
+  } deriving stock (Eq)
+
+instance Semigroup BufferedLogAgg where
+  (<>) x y =
+    BufferedLogAgg
+      { bufferedLogAggCount = bufferedLogAggCount x + bufferedLogAggCount y
+      , bufferedLogAggMetas = bufferedLogAggMetas x <> bufferedLogAggMetas y
+      }
+
+instance ToJSON BufferedLogAgg where
+  toJSON bufferedLogAgg =
+    object
+      $ "count" .= count
+      : ["metas" .= DList.toList metas | not $ null metas]
+    where
+    BufferedLogAgg
+      { bufferedLogAggCount = count
+      , bufferedLogAggMetas = metas
+      } = bufferedLogAgg
 
 -- $disclaimer
 --

--- a/otel-api-common/library/OTel/API/Common/Logging.hs
+++ b/otel-api-common/library/OTel/API/Common/Logging.hs
@@ -1,0 +1,28 @@
+module OTel.API.Common.Logging
+  ( Internal.withBufferedLogger
+
+  , Internal.BufferedLoggerSpec
+  , Internal.defaultBufferedLoggerSpec
+  , Internal.bufferedLoggerSpecShouldBuffer
+  , Internal.bufferedLoggerSpecLogger
+  , Internal.bufferedLoggerSpecFlushPeriod
+  , Internal.bufferedLoggerSpecFlushTimeout
+  , Internal.bufferedLoggerSpecOnFlushTimeout
+  , Internal.bufferedLoggerSpecOnFlushException
+  , Internal.bufferedLoggerSpecOnFlushExceptionLogger
+  , Internal.bufferedLoggerSpecIncludeLogAggregate
+
+  , Internal.includeLogAggregateViaAeson
+
+  , Internal.BufferedLogs
+  , Internal.BufferedLog
+  , Internal.bufferedLogLoc
+  , Internal.bufferedLogLogSource
+  , Internal.bufferedLogLogLevel
+  , Internal.bufferedLogLogStr
+  , Internal.BufferedLogAgg
+  , Internal.bufferedLogAggCount
+  , Internal.bufferedLogAggMetas
+  ) where
+
+import qualified OTel.API.Common.Internal as Internal

--- a/otel-api-common/otel-api-common.cabal
+++ b/otel-api-common/otel-api-common.cabal
@@ -38,6 +38,7 @@ library
       OTel.API.Common.InstrumentationScope
       OTel.API.Common.Internal
       OTel.API.Common.KV
+      OTel.API.Common.Logging
       OTel.API.Common.Timestamp
   hs-source-dirs:
       library
@@ -46,7 +47,9 @@ library
   ghc-options: -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson
+    , async
     , base >=4.11.1.0 && <5
+    , bytestring
     , containers
     , dlist
     , hashable
@@ -66,6 +69,7 @@ test-suite otel-api-common-test-suite
   other-modules:
       Test.OTel.API.Common.AttributesSpec
       Test.OTel.API.Common.IsTest
+      Test.OTel.API.Common.LoggingSpec
   hs-source-dirs:
       test-suite
   default-extensions:
@@ -77,7 +81,9 @@ test-suite otel-api-common-test-suite
       aeson
     , base
     , hspec
+    , monad-logger-aeson
     , otel-api-common
     , scientific
+    , stm
     , text
   default-language: Haskell2010

--- a/otel-api-common/otel-api-common.cabal
+++ b/otel-api-common/otel-api-common.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,6 +32,9 @@ library
       OTel.API.Common
       OTel.API.Common.Attributes
       OTel.API.Common.CPS
+      OTel.API.Common.Handlers
+      OTel.API.Common.Handlers.OnException
+      OTel.API.Common.Handlers.OnTimeout
       OTel.API.Common.InstrumentationScope
       OTel.API.Common.Internal
       OTel.API.Common.KV
@@ -47,8 +50,12 @@ library
     , containers
     , dlist
     , hashable
+    , monad-logger-aeson
+    , safe-exceptions
     , scientific
     , text
+    , transformers
+    , unliftio-core
     , unordered-containers
     , vector
   default-language: Haskell2010

--- a/otel-api-common/package.yaml
+++ b/otel-api-common/package.yaml
@@ -28,8 +28,10 @@ ghc-options:
 
 library:
   dependencies:
+  - async
   - aeson
   - base >=4.11.1.0 && <5
+  - bytestring
   - containers
   - dlist
   - hashable
@@ -56,8 +58,10 @@ tests:
     - aeson
     - base
     - hspec
+    - monad-logger-aeson
     - otel-api-common
     - scientific
+    - stm
     - text
     when:
     - condition: false

--- a/otel-api-common/package.yaml
+++ b/otel-api-common/package.yaml
@@ -33,8 +33,12 @@ library:
   - containers
   - dlist
   - hashable
+  - monad-logger-aeson
+  - safe-exceptions
   - scientific
   - text
+  - transformers
+  - unliftio-core
   - unordered-containers
   - vector
   source-dirs: library

--- a/otel-api-common/test-suite/Test/OTel/API/Common/LoggingSpec.hs
+++ b/otel-api-common/test-suite/Test/OTel/API/Common/LoggingSpec.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Test.OTel.API.Common.LoggingSpec
+  ( spec
+  ) where
+
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TQueue (TQueue, flushTQueue, newTQueueIO, writeTQueue)
+import Control.Exception (ArithException(..), throwIO)
+import Control.Monad (guard, replicateM_)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Logger.Aeson
+  ( Loc(..), LogLevel(LevelDebug, LevelError, LevelInfo), LoggingT(runLoggingT), Message(..)
+  , ToLogStr(toLogStr), (.=), LogSource, LogStr, logDebug, logError, logInfo
+  )
+import Data.Aeson (Value(Array), object)
+import Data.Text (Text)
+import OTel.API.Common.Logging
+  ( BufferedLoggerSpec
+    ( bufferedLoggerSpecFlushPeriod, bufferedLoggerSpecFlushTimeout
+    , bufferedLoggerSpecIncludeLogAggregate, bufferedLoggerSpecLogger
+    , bufferedLoggerSpecOnFlushExceptionLogger, bufferedLoggerSpecShouldBuffer
+    )
+  , defaultBufferedLoggerSpec, includeLogAggregateViaAeson, withBufferedLogger
+  )
+import Prelude
+import System.Timeout (timeout)
+import Test.Hspec (HasCallStack, Spec, describe, expectationFailure, it, shouldBe)
+
+testLogging
+  :: forall m
+   . (MonadIO m)
+  => (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
+  -> m ()
+testLogging logger = do
+ flip runLoggingT logger do
+   logError $ "Ruh roh" :# ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+   logDebug "Doing stuff..."
+   logInfo $ "Something of interest" :# ["howImportant" .= ("very" :: Text)]
+
+-- Note that these tests do not test the period-based flushing of the buffered
+-- logger, as that would likely just result in flaky tests. Instead, we rely on
+-- the shutdown flush to check buffered logs.
+spec :: Spec
+spec = do
+  describe "withBufferedLogger" do
+
+    it "Unbuffered logs are logged immediately" do
+      queue <- newTQueueIO
+      let bufferedLoggerSpec =
+            defaultBufferedLoggerSpec
+              { bufferedLoggerSpecLogger = stmLogger queue
+              , bufferedLoggerSpecFlushPeriod = maxBound @Int
+              , bufferedLoggerSpecOnFlushExceptionLogger =
+                  \_loc _logSource _logLevel _logStr ->
+                    expectationFailure $
+                      "bufferedLoggerSpecOnFlushExceptionLogger should not "
+                        <> "have been called"
+              }
+      withBufferedLogger bufferedLoggerSpec \logger -> do
+        replicateM_ 3 $ testLogging logger
+        let expectedLogs =
+              [ (l (43, 4) (43, 12), "", LevelError, "Ruh roh" :# ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)])
+              , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+              , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+              ]
+        expectedQueueElems False queue $ mconcat [expectedLogs, expectedLogs, expectedLogs]
+      expectedQueueElems False queue $ mconcat []
+
+    it "Buffered logs are logged on flush" do
+      queue <- newTQueueIO
+      let bufferedLoggerSpec =
+            defaultBufferedLoggerSpec
+              { bufferedLoggerSpecShouldBuffer =
+                  \_loc _logSource logLevel _logStr ->
+                    logLevel >= LevelError
+              , bufferedLoggerSpecLogger = stmLogger queue
+              , bufferedLoggerSpecFlushPeriod = maxBound @Int
+              , bufferedLoggerSpecOnFlushExceptionLogger =
+                  \_loc _logSource _logLevel _logStr ->
+                    expectationFailure $
+                      "bufferedLoggerSpecOnFlushExceptionLogger should not "
+                        <> "have been called"
+              , bufferedLoggerSpecIncludeLogAggregate =
+                  includeLogAggregateViaAeson Just
+              }
+      withBufferedLogger bufferedLoggerSpec \logger -> do
+        replicateM_ 3 $ testLogging logger
+        -- All logs less than error level are unbuffered and logged immediately.
+        expectedQueueElems False queue
+          [ (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          ]
+      -- A flush happens when @withBufferedLogger@ returns.
+      expectedQueueElems False queue
+        [ (l (43, 4) (43, 12), "", LevelError, "Ruh roh" :#
+            [ "bufferedLogAgg" .= object
+                [ "count" .= (3 :: Int)
+                , "metas" .=  Array
+                    [ object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    ]
+                ]
+            , "bufferedLogger" .= object
+                [ "flushPeriod" .= maxBound @Int
+                , "flushTimeout" .= bufferedLoggerSpecFlushTimeout defaultBufferedLoggerSpec
+                ]
+            ]
+          )
+        ]
+
+    it "Exceptions are handled" do
+      queue <- newTQueueIO
+      let bufferedLoggerSpec =
+            defaultBufferedLoggerSpec
+              { bufferedLoggerSpecShouldBuffer =
+                  \_loc _logSource logLevel _logStr ->
+                    logLevel >= LevelError
+              , bufferedLoggerSpecLogger = \loc logSource logLevel logStr ->
+                  if logLevel >= LevelError then do
+                    throwIO Overflow
+                  else do
+                    stmLogger queue loc logSource logLevel logStr
+              , bufferedLoggerSpecFlushPeriod = maxBound @Int
+              , bufferedLoggerSpecOnFlushExceptionLogger = stmLogger queue
+              }
+      withBufferedLogger bufferedLoggerSpec \logger -> do
+        replicateM_ 3 $ testLogging logger
+        -- All logs less than error level are unbuffered and logged immediately.
+        expectedQueueElems False queue
+          [ (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          ]
+      -- A flush happens when @withBufferedLogger@ returns.
+      expectedQueueElems True queue
+        [ (lInternal (1_007, 9) (1_007, 17), "", LevelError, "Ignoring exception from flushing buffered log" :#
+            [ "exception" .= ("arithmetic overflow" :: Text)
+            , "bufferedLog" .= object
+                [ "loc" .= object
+                    [ "char" .= (4 :: Int)
+                    , "file" .= ("test-suite/Test/OTel/API/Common/LoggingSpec.hs" :: Text)
+                    , "line" .= (43 :: Int)
+                    , "module" .= ("Test.OTel.API.Common.LoggingSpec" :: Text)
+                    , "package" .= ("main" :: Text)
+                    ]
+                , "level" .= ("error" :: Text)
+                , "source" .= ("" :: Text)
+                , "text" .= ("Ruh roh" :: Text)
+                ]
+            , "bufferedLogAgg" .= object
+                [ "count" .= (3 :: Int)
+                , "metas" .=  Array
+                    [ object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                    ]
+                ]
+            , "bufferedLogger" .= object
+                [ "flushPeriod" .= maxBound @Int
+                , "flushTimeout" .= bufferedLoggerSpecFlushTimeout defaultBufferedLoggerSpec
+                ]
+            ]
+          )
+        ]
+
+    it "Timeouts are handled" do
+      queue <- newTQueueIO
+      let bufferedLoggerSpec =
+            defaultBufferedLoggerSpec
+              { bufferedLoggerSpecShouldBuffer =
+                  \_loc _logSource logLevel _logStr ->
+                    logLevel >= LevelError
+              , bufferedLoggerSpecLogger = stmLogger queue
+              , bufferedLoggerSpecFlushPeriod = maxBound @Int
+              , bufferedLoggerSpecFlushTimeout = 0
+              , bufferedLoggerSpecOnFlushExceptionLogger = stmLogger queue
+              }
+      withBufferedLogger bufferedLoggerSpec \logger -> do
+        replicateM_ 3 $ testLogging logger
+        -- All logs less than error level are unbuffered and logged immediately.
+        expectedQueueElems False queue
+          [ (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          , (l (44, 4) (44, 12), "", LevelDebug, "Doing stuff...")
+          , (l (45, 4) (45, 11), "", LevelInfo, "Something of interest" :# ["howImportant" .= ("very" :: Text)])
+          ]
+      -- A flush happens when @withBufferedLogger@ returns.
+      expectedQueueElems True queue
+        [ (lInternal (992, 9) (992, 17), "", LevelError, "Flushing buffered logs took too long" :#
+            [ "timeoutMicros" .= (0 :: Int)
+            , "unflushedLogs" .= Array
+                [ object
+                    [ "bufferedLog" .= object
+                        [ "loc" .= object
+                            [ "char" .= (4 :: Int)
+                            , "file" .= ("test-suite/Test/OTel/API/Common/LoggingSpec.hs" :: Text)
+                            , "line" .= (43 :: Int)
+                            , "module" .= ("Test.OTel.API.Common.LoggingSpec" :: Text)
+                            , "package" .= ("main" :: Text)
+                            ]
+                        , "level" .= ("error" :: Text)
+                        , "source" .= ("" :: Text)
+                        , "text" .= ("Ruh roh" :: Text)
+                        ]
+                    , "bufferedLogAgg" .= object
+                        [ "count" .= (3 :: Int)
+                        , "metas" .=  Array
+                            [ object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                            , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                            , object ["floop" .= ("bloorp" :: Text), "bonk" .= (42 :: Int)]
+                            ]
+                        ]
+                    ]
+                ]
+            , "bufferedLogger" .= object
+                [ "flushPeriod" .= maxBound @Int
+                , "flushTimeout" .= (0 :: Int)
+                ]
+            ]
+          )
+        ]
+
+expectedQueueElems
+  :: (HasCallStack)
+  => Bool
+  -> TQueue (Loc, LogSource, LogLevel, LogStr)
+  -> [(Loc, LogSource, LogLevel, Message)]
+  -> IO ()
+expectedQueueElems shouldIgnoreLoc queue expectedElems = do
+  mResult <- timeout 3_000_000 $ atomically do
+    actualElems <- getActualElems
+    guard $ fmap locUpdate actualElems == expectedElems'
+  case mResult of
+    Just () -> pure ()
+    Nothing -> do
+      actualElems <- atomically getActualElems
+      -- If a test is failing and the output is hard to decipher, it can be
+      -- convenient to temporarily change the @expectationFailure@ to the
+      -- following:
+      --
+      actualElems `shouldBe` expectedElems'
+      expectationFailure $
+        "expectedQueueElems timed out: "
+          <> "expected=" <> show expectedElems' <> ", "
+          <> "actual=" <> show actualElems
+  where
+  getActualElems = fmap locUpdate <$> flushTQueue queue
+
+  expectedElems' =
+    flip fmap expectedElems \(loc, logSource, logLevel, msg) ->
+      locUpdate (loc, logSource, logLevel, toLogStr msg)
+
+  locUpdate (loc, logSource, logLevel, msg)
+    | shouldIgnoreLoc =
+        (dummyLoc, logSource, logLevel, msg)
+    | otherwise = (loc, logSource, logLevel, msg)
+
+stmLogger
+  :: TQueue (Loc, LogSource, LogLevel, LogStr)
+  -> Loc
+  -> LogSource
+  -> LogLevel
+  -> LogStr
+  -> IO ()
+stmLogger queue loc logSource logLevel logStr = do
+  atomically $ writeTQueue queue (loc, logSource, logLevel, logStr)
+
+l :: (Int, Int) -> (Int, Int) -> Loc
+l start end =
+  Loc
+    { loc_filename = "test-suite/Test/OTel/API/Common/LoggingSpec.hs"
+    , loc_package = "main"
+    , loc_module = "Test.OTel.API.Common.LoggingSpec"
+    , loc_start = start
+    , loc_end = end
+    }
+
+lInternal :: (Int, Int) -> (Int, Int) -> Loc
+lInternal start end =
+  Loc
+    { loc_filename = "library/OTel/API/Common/Internal.hs"
+    , loc_package = "TESTS SHOULD IGNORE THIS FIELD VIA expectedQueueElems INPUT"
+    , loc_module = "OTel.API.Common.Internal"
+    , loc_start = start
+    , loc_end = end
+    }
+
+dummyLoc :: Loc
+dummyLoc =
+  Loc
+    { loc_filename = "DUMMY FILENAME"
+    , loc_package = "DUMMY PACKAGE"
+    , loc_module = "DUMMY MODULE"
+    , loc_start = (1, 2)
+    , loc_end = (3, 4)
+    }

--- a/otel-sdk-trace/library/OTel/SDK/Trace/Handlers.hs
+++ b/otel-sdk-trace/library/OTel/SDK/Trace/Handlers.hs
@@ -1,9 +1,5 @@
 module OTel.SDK.Trace.Handlers
-  ( module OTel.SDK.Trace.Handlers.OnException
-  , module OTel.SDK.Trace.Handlers.OnSpansExported
-  , module OTel.SDK.Trace.Handlers.OnTimeout
+  ( module OTel.SDK.Trace.Handlers.OnSpansExported
   ) where
 
-import OTel.SDK.Trace.Handlers.OnException
 import OTel.SDK.Trace.Handlers.OnSpansExported
-import OTel.SDK.Trace.Handlers.OnTimeout

--- a/otel-sdk-trace/library/OTel/SDK/Trace/Handlers/OnException.hs
+++ b/otel-sdk-trace/library/OTel/SDK/Trace/Handlers/OnException.hs
@@ -1,7 +1,0 @@
-module OTel.SDK.Trace.Handlers.OnException
-  ( Internal.OnException
-  , Internal.askException
-  , Internal.askExceptionMetadata
-  ) where
-
-import qualified OTel.SDK.Trace.Internal as Internal

--- a/otel-sdk-trace/otel-sdk-trace.cabal
+++ b/otel-sdk-trace/otel-sdk-trace.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,9 +32,7 @@ library
       OTel.SDK.Trace
       OTel.SDK.Trace.Common
       OTel.SDK.Trace.Handlers
-      OTel.SDK.Trace.Handlers.OnException
       OTel.SDK.Trace.Handlers.OnSpansExported
-      OTel.SDK.Trace.Handlers.OnTimeout
       OTel.SDK.Trace.IdGenerator
       OTel.SDK.Trace.Internal
       OTel.SDK.Trace.Sampler

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-19
+resolver: lts-20.12
 packages:
 - ./otel-api-baggage
 - ./otel-api-baggage-core

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 636956
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/9/19.yaml
-    sha256: b40962d62404e8389ddc2f4228170871b1a6d62b66e7d532a6c798426f047603
-  original: nightly-2022-09-19
+    sha256: af5d667f6096e535b9c725a72cffe0f6c060e0568d9f9eeda04caee70d0d9d2d
+    size: 649133
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/12.yaml
+  original: lts-20.12

--- a/stack/stack-nightly.yaml
+++ b/stack/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-19
+resolver: lts-20.12
 packages:
 - ../otel-api-baggage
 - ../otel-api-baggage-core


### PR DESCRIPTION
This PR adds to `otel-api-common` a means for buffering logs, where logs selected via a user-specified predicate will be buffered then later flushed as aggregates, and all other logs will be logged immediately.

The motivation for these changes came from running `opentelemetry-haskell` in production. When using the OTLP span exporter and the observability backend (e.g. Honeycomb) is unavailable, there are a few error states that can be encountered. Depending upon application traffic, this can result in surges of error logging. Rapidly logging every error, especially when the errors are often duplicates, is inappropriate for most production applications. It's worth pointing out that more surgical changes could've been made to `otel-sdk-trace`'s `otlpSpanExporter`, but the approach taken in this PR offers some level of future-proofing if users encounter other portions of `opentelemetry-haskell` that could benefit from log buffering.

Using the `withBufferedLogger` function in this PR, users can granularly control which of their loggers support buffering, and for those buffered loggers, users can specify exactly which log messages should be buffered.

An argument could be made that these changes should live somewhere else (e.g. `monad-logger-aeson` or some other package), but it is convenient to leverage `opentelemetry-haskell`'s `OnException` and `OnTimeout` handlers in the buffered logger's config and I'd rather not move those handlers out to some separate package at this time.

Note that it is not recommended to buffer all log messages. Buffering error logs should be fine, but it is exceedingly unlikely that the guts of the implementation here has appropriate throughput for buffering all log messages under the sun.