### PR TITLE
Redact sensitive headers when OTLP span exporter encounters HTTP exceptions

### DIFF
--- a/otel-sdk-trace/library/OTel/SDK/Trace/SpanExporter/OTLP.hs
+++ b/otel-sdk-trace/library/OTel/SDK/Trace/SpanExporter/OTLP.hs
@@ -8,6 +8,8 @@ module OTel.SDK.Trace.SpanExporter.OTLP
   , Internal.otlpSpanExporterSpecTimeout
   , Internal.otlpSpanExporterSpecProtocol
   , Internal.otlpSpanExporterSpecHeaders
+  , Internal.otlpSpanExporterSpecRedactedRequestHeaders
+  , Internal.otlpSpanExporterSpecRedactedResponseHeaders
   , Internal.otlpSpanExporterSpecLogger
   , Internal.otlpSpanExporterSpecWorkerQueueSize
   , Internal.otlpSpanExporterSpecWorkerCount

--- a/otel-sdk-trace/otel-sdk-trace.cabal
+++ b/otel-sdk-trace/otel-sdk-trace.cabal
@@ -55,6 +55,7 @@ library
     , base >=4.11.1.0 && <5
     , bytestring
     , clock
+    , containers
     , dlist
     , http-client
     , http-client-tls

--- a/otel-sdk-trace/package.yaml
+++ b/otel-sdk-trace/package.yaml
@@ -33,6 +33,7 @@ library:
   - base >=4.11.1.0 && <5
   - bytestring
   - clock
+  - containers
   - dlist
   - http-client
   - http-client-tls


### PR DESCRIPTION
This PR adds a couple options to `OTLPSpanExporterSpec` where users can specify sensitive request/response header names, and these headers will be redacted from the request/response prior to the OTLP span exporter logging them. This is useful to avoid leaking sensitive data like API keys in log messages when the OTLP span exporter encounters `http-client` exceptions, as these exceptions contain the underlying `Request` and `Response`.