### PR TITLE
Consolidate logger passing

### DIFF
--- a/otel-api-common/library/OTel/API/Common/Logging.hs
+++ b/otel-api-common/library/OTel/API/Common/Logging.hs
@@ -1,5 +1,7 @@
 module OTel.API.Common.Logging
-  ( Internal.withBufferedLogger
+  ( Internal.Logger
+
+  , Internal.withBufferedLogger
 
   , Internal.BufferedLoggerSpec
   , Internal.defaultBufferedLoggerSpec

--- a/otel-sdk-trace/executables/otlp-tracing-example.hs
+++ b/otel-sdk-trace/executables/otlp-tracing-example.hs
@@ -88,8 +88,6 @@ buildTracerProviderSpec = do
           [ simpleSpanProcessor defaultSimpleSpanProcessorSpec
               { simpleSpanProcessorSpecExporter =
                   otlpSpanExporter defaultOTLPSpanExporterSpec
-                    { otlpSpanExporterSpecLogger = defaultOutput stdout
-                    }
               }
           ]
       , tracerProviderSpecSampler = alwaysOnSampler

--- a/otel-sdk-trace/library/OTel/SDK/Trace/SpanExporter/OTLP.hs
+++ b/otel-sdk-trace/library/OTel/SDK/Trace/SpanExporter/OTLP.hs
@@ -10,7 +10,6 @@ module OTel.SDK.Trace.SpanExporter.OTLP
   , Internal.otlpSpanExporterSpecHeaders
   , Internal.otlpSpanExporterSpecRedactedRequestHeaders
   , Internal.otlpSpanExporterSpecRedactedResponseHeaders
-  , Internal.otlpSpanExporterSpecLogger
   , Internal.otlpSpanExporterSpecWorkerQueueSize
   , Internal.otlpSpanExporterSpecWorkerCount
   , Internal.otlpSpanExporterSpecRetryPolicy

--- a/otel-sdk-trace/test-suite/Test/OTel/SDK/Trace/OTLPSpanExporterSpec.hs
+++ b/otel-sdk-trace/test-suite/Test/OTel/SDK/Trace/OTLPSpanExporterSpec.hs
@@ -41,7 +41,7 @@ import OTel.API.Trace.Core.Internal (Span(..))
 import OTel.SDK.Resource.Core (buildResource, defaultResourceBuilder)
 import OTel.SDK.Trace
   ( OTLPSpanExporterSpec(..), SpanExportResult(..), SpanExporter(..), Batch
-  , defaultOTLPSpanExporterSpec, otlpSpanExporter, otlpSpanExporterSpecLogger
+  , defaultOTLPSpanExporterSpec, otlpSpanExporter
   )
 import OTel.SDK.Trace.Internal (buildSpanExporter)
 import Prelude
@@ -247,7 +247,7 @@ instance IsTest RetriesTestCase where
     logQueue <- newTQueueIO
     let logger = stmLogger logQueue
 
-    otlpSpanExporter (otlpSpanExporterSpec logger manager) \spanExporterSpec -> do
+    otlpSpanExporter (otlpSpanExporterSpec manager) logger \spanExporterSpec -> do
       spanExporter <- buildSpanExporter resource logger spanExporterSpec
       go (spanExporterExport spanExporter) `finally` spanExporterShutdown spanExporter
       checkLogs updateMeta logQueue expectedLogs
@@ -274,15 +274,11 @@ instance IsTest RetriesTestCase where
         , spanInstrumentationScope = "foo"
         }
 
-    otlpSpanExporterSpec
-      :: (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
-      -> Manager
-      -> OTLPSpanExporterSpec
-    otlpSpanExporterSpec logger manager =
+    otlpSpanExporterSpec :: Manager -> OTLPSpanExporterSpec
+    otlpSpanExporterSpec manager =
       defaultOTLPSpanExporterSpec
         { otlpSpanExporterSpecEndpoint =
             fromJust $ parseURI $ "http://localhost:" <> show serverPort
-        , otlpSpanExporterSpecLogger = logger
         , otlpSpanExporterSpecManager = manager
         }
 

--- a/otel-sdk-trace/test-suite/Test/OTel/SDK/TraceSpec.hs
+++ b/otel-sdk-trace/test-suite/Test/OTel/SDK/TraceSpec.hs
@@ -181,7 +181,7 @@ testTracerProviderSpec nanosRef traceIdRef spanIdRef spanQueue =
           modifyTVar' nanosRef succ
           pure $ timestampFromNanoseconds x
     , tracerProviderSpecLogger = defaultOutput stdout
-    , tracerProviderSpecIdGenerator =
+    , tracerProviderSpecIdGenerator = \_logger ->
         with IdGeneratorSpec
           { idGeneratorSpecName = "test"
           , idGeneratorSpecGenTraceId =


### PR DESCRIPTION
There was a wrinkle in `otel-sdk-trace` where when users were using `otlpSpanExporter`, they'd have to redundantly pass in their logger, even though they already gave their logger to the tracer provider. This wrinkle revealed that this would be a potential future issue for multiple areas and not just span exporters: custom samplers, ID generators, span processors, etc. This PR uniformly updates the interfaces for acquiring these things so that they go from:

```haskell
(FooSpec -> IO a) -> IO a
```

to

```haskell
Logger -> (FooSpec -> IO a) -> IO a
```

As a concrete example, `SpanProcessorSpec`'s field for getting its associated span exporter used to look like this:

```haskell
data SpanProcessorSpec = SpanProcessorSpec
  { spanProcessorSpecExporter
      :: forall a. (SpanExporterSpec -> IO a) -> IO a
    -- ...
  }
```

and now looks like this:

```haskell
data SpanProcessorSpec = SpanProcessorSpec
  { spanProcessorSpecExporter
      :: forall a. Logger -> (SpanExporterSpec -> IO a) -> IO a
    -- ...
  }
```

This change to the interface for acquiring these various things lets us take in a logger from the user in exactly one place: the tracer provider. As the tracer provider acquires all the pieces it needs (span processors, ID generator, sampler, etc.), it can now thread that single logger through everywhere so that the user-specified logic for _acquiring_ each piece also has access to that same logger. Note that each piece's custom handler code (e.g. `SpanProcessorSpec`'s `spanProcessorSpecShutdown :: SpanProcessorM ()`) already had access to this logger before this PR. The point of this PR is to also share that same logger in the logic that _acquires_ the piece (e.g. `SpanProcessorSpec`) itself.